### PR TITLE
Allow mods to patch tilt config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,22 @@
 # Installation
 
 1) Go to the [latest release](../../releases/latest) page and download the zip file
-3) Decompress the downloaded .zip and put it in the KSP folder
-4) If you want to edit the current tilts, edit the file `GameData\TiltEm\PlanetTilt.cfg` the first number is the celestial body index, the second number is the degrees of tilt.  
+2) Decompress the downloaded .zip and put it in the KSP folder
+3) If you want to edit the current tilts, edit the file `GameData\TiltEm\PlanetTilt.cfg` the first number is the celestial body index, the second number is the degrees of tilt.
 Have a look at the [wiki](../../wiki) to see what index refers to what body name in the default KSP planet pack
+
+# Modding
+
+You can use ModuleManager patches to edit the ﻿PlanetTilts config node without editing the cfg file:
+
+```
+@PlanetTilts
+{
+    %3  = 15
+    %11 = 25
+    %12 = 35
+}
+```
 
 ---
 

--- a/TiltEm/TiltEm.cs
+++ b/TiltEm/TiltEm.cs
@@ -29,16 +29,14 @@ namespace TiltEm
             TiltEmGui.DrawGui();
         }
 #endif
-        
+
         private static void FillTiltDictionary()
         {
             try
             {
-                var path = TiltEmUtil.CombinePaths(UrlDir.ApplicationRootPath, "GameData", "TiltEm", "PlanetTilt.cfg");
-                if (File.Exists(path))
+                foreach (var urlCfg in GameDatabase.Instance.GetConfigs("PlanetTilts"))
                 {
-                    var cfgNode = ConfigNode.Load(path);
-                    foreach (var node in cfgNode.GetNodes()[0].GetNodes())
+                    foreach (var value in urlCfg.config.values.Cast<ConfigNode.Value>())
                     {
                         var body = FlightGlobals.GetBodyByName(node.name);
                         if (body != null)
@@ -56,14 +54,10 @@ namespace TiltEm
                         }
                     }
                 }
-                else
-                {
-                    Debug.LogWarning($"[TiltEm]: No PlanetTilt.cfg found on path: {path}");
-                }
             }
             catch (Exception e)
             {
-                Debug.LogError($"[TiltEm]: Error while reading PlanetTilt.cfg. Details: {e}");
+                Debug.LogError($"[TiltEm]: Error while reading PlanetTilts config node. Details: {e}");
             }
         }
 


### PR DESCRIPTION
## Motivation

This mod is going to be very popular with planet pack makers. They'll want to be able to set custom tilts for their custom planets.

Currently the tilts are loaded only from `GameData/TiltEm/PlanetTilt.cfg`, which would have to be replaced with a given planet pack's settings. It has been a problem historically when mods need to change files installed by other mods for a variety of reasons (conflicts with other mods also changing the same file, difficulty of uninstalling, etc.).

## Changes

Luckily coordinating changes to shared config is a solved problem in KSP modding thanks to ModuleManager.

Now instead of loading the `PlanetTilts` object from just `GameData/TiltEm/PlanetTilt.cfg`, the mod allows the file to be auto-loaded by the core game engine, and then accesses it via `GameDatabase.Instance.GetConfigs`, as [Kopernicus also does](https://github.com/Kopernicus/Kopernicus/blob/b4f265b1b6db648e94702dc82079f957ac9d1648/src/Kopernicus/Injector.cs#L109-L110). This allows a planet pack mod to include tilt settings in its own `cfg` file, overriding the defaults with ModuleManager.

The documentation is updated with some very simple instructions for modders.