### PR TITLE
Fix version file URL property

### DIFF
--- a/Resources/TiltEm.version
+++ b/Resources/TiltEm.version
@@ -1,6 +1,6 @@
 {
     "NAME":     "Tilt 'Em",
-    "URL":      "https://github.com/LunaMultiplayer/TiltEm/tree/master/TiltEm/TiltEm.version",
+    "URL":      "https://github.com/LunaMultiplayer/TiltEm/raw/master/Resources/TiltEm.version",
     "DOWNLOAD": "https://github.com/LunaMultiplayer/TiltEm/releases/download/1.2.2/TiltEm.1.2.2.zip",
     "GITHUB": {
         "USERNAME":   "LunaMultiplayer",


### PR DESCRIPTION
The version file got moved into a Resources folder after #1, so the current URL property is a 404.
Now it's fixed.

Tagging @gavazquez because not everyone has GitHub notifications enabled for pull requests.